### PR TITLE
Update to Python 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.10-slim
+FROM python:3.13-slim
 
 # Set the working directory in the container
 WORKDIR /usr/src/app
@@ -8,11 +8,11 @@ WORKDIR /usr/src/app
 COPY requirements.txt ./
 
 # Install any needed packages specified in requirements.txt
-RUN python -m venv venv310
-RUN . venv310/bin/activate && pip install --no-cache-dir -r requirements.txt
+RUN python -m venv venv313
+RUN . venv313/bin/activate && pip install --no-cache-dir -r requirements.txt
 
 # Copy the rest of the application
 COPY . .
 
 # Run app.py when the container launches
-CMD [ "venv310/bin/python", "scraper.py" ]
+CMD [ "venv313/bin/python", "scraper.py" ]

--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,6 @@
 build_from:
-  aarch64: 'homeassistant/aarch64-base-python:3.9'
-  amd64: 'homeassistant/amd64-base-python:3.9'
-  armhf: 'homeassistant/armhf-base-python:3.9'
-  armv7: 'homeassistant/armv7-base-python:3.9'
-  i386: 'homeassistant/i386-base-python:3.9'
+  aarch64: 'homeassistant/aarch64-base-python:3.13'
+  amd64: 'homeassistant/amd64-base-python:3.13'
+  armhf: 'homeassistant/armhf-base-python:3.13'
+  armv7: 'homeassistant/armv7-base-python:3.13'
+  i386: 'homeassistant/i386-base-python:3.13'


### PR DESCRIPTION
## Summary
- upgrade the Docker base image to `python:3.13-slim`
- create a `venv313` virtualenv in Dockerfile
- bump Home Assistant base images to Python 3.13

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68650047823c833193c834f475129810